### PR TITLE
Iteration 1 Part 1: Representatives - Fix Legacy Code /6

### DIFF
--- a/app/models/representative.rb
+++ b/app/models/representative.rb
@@ -17,6 +17,8 @@ class Representative < ApplicationRecord
         end
       end
 
+      next if Representative.find_by(name: official.name, title: title_temp).present?
+
       rep = Representative.create!({ name: official.name, ocdid: ocdid_temp,
           title: title_temp })
       reps.push(rep)

--- a/spec/models/representative_spec.rb
+++ b/spec/models/representative_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Representative, type: :model do
+  describe '.civic_api_to_representative_params' do
+    let(:rep_info) do
+      OpenStruct.new(
+        officials: [OpenStruct.new(name: 'Ash Ketchum')],
+        offices:   [OpenStruct.new(name: 'Governor', official_indices: [0], division_id: 'Pallet_Town')]
+      )
+    end
+
+    it "will create a new representative if they don't exist" do
+      described_class.create(name: 'Misty Waterflower', title: 'Governor')
+      expect { described_class.civic_api_to_representative_params(rep_info) }.to change(described_class, :count).by(1)
+    end
+
+    it "won't create a new representative if they already exist" do
+      described_class.create(name: 'Ash Ketchum', title: 'Governor')
+      expect { described_class.civic_api_to_representative_params(rep_info) }.not_to change(described_class, :count)
+    end
+  end
+end


### PR DESCRIPTION
In this PR, I have submitted changed which will
1. Restrict a representative from being creating if they have already been created
2. Create a check which will make sure the functionality of the previous item works properly
3. Create a check which will make sure that we are able to add new representatives that have not already been created

#6 